### PR TITLE
Simplify intra process demos

### DIFF
--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(intra_process_demo_msgs REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc videoio)
 
@@ -33,14 +33,14 @@ add_executable(two_node_pipeline
   src/two_node_pipeline/two_node_pipeline.cpp)
 target_link_libraries(two_node_pipeline
   rclcpp::rclcpp
-  ${std_msgs_TARGETS})
+  ${intra_process_demo_msgs_TARGETS})
 
   # Simple example of a cyclic pipeline which uses no allocation while iterating.
 add_executable(cyclic_pipeline
   src/cyclic_pipeline/cyclic_pipeline.cpp)
 target_link_libraries(cyclic_pipeline
   rclcpp::rclcpp
-  ${std_msgs_TARGETS})
+  ${intra_process_demo_msgs_TARGETS})
 
 # A single program with one of each of the image pipeline demo nodes.
 add_executable(image_pipeline_all_in_one

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -14,77 +14,78 @@
 
 #include <chrono>
 #include <cinttypes>
-#include <cstdio>
 #include <memory>
-#include <string>
-#include <utility>
 
-#include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/int32.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
+#include "intra_process_demo_msgs/msg/data.hpp"
 
 using namespace std::chrono_literals;
+using namespace std::placeholders;
 
-// Node that produces messages.
-struct Producer : public rclcpp::Node
+class Publisher : public rclcpp::Node
 {
-  Producer(const std::string & name, const std::string & output)
-  : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
+public:
+  Publisher()
+  : Node(("publisher"), rclcpp::NodeOptions().use_intra_process_comms(true))
   {
-    // Create a publisher on the output topic.
-    pub_ = this->create_publisher<std_msgs::msg::Int32>(output, 10);
-    std::weak_ptr<std::remove_pointer<decltype(pub_.get())>::type> captured_pub = pub_;
-    // Create a timer which publishes on the output topic at ~1Hz.
-    auto callback = [captured_pub]() -> void {
-        auto pub_ptr = captured_pub.lock();
-        if (!pub_ptr) {
-          return;
-        }
-        static int32_t count = 0;
-        std_msgs::msg::Int32::UniquePtr msg(new std_msgs::msg::Int32());
-        msg->data = count++;
-        printf(
-          "Published message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
-          reinterpret_cast<std::uintptr_t>(msg.get()));
-        pub_ptr->publish(std::move(msg));
-      };
-    timer_ = this->create_wall_timer(1s, callback);
+    publisher_ = this->create_publisher<intra_process_demo_msgs::msg::Data>("number", 10);
+    timer_ = this->create_wall_timer(
+      1s, std::bind(&Publisher::timer_callback, this));
   }
 
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
+private:
+  void timer_callback()
+  {
+    auto msg = std::make_unique<intra_process_demo_msgs::msg::Data>();
+    msg->stamp = rclcpp::Clock(RCL_SYSTEM_TIME).now();
+    msg->value = count++;
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Published message with value: %d, and address: 0x%" PRIXPTR,
+      msg->value,
+      reinterpret_cast<std::uintptr_t>(msg.get()));
+    publisher_->publish(std::move(msg));
+  }
+
+  rclcpp::Publisher<intra_process_demo_msgs::msg::Data>::SharedPtr publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
+  int32_t count = 0;
 };
 
-// Node that consumes messages.
-struct Consumer : public rclcpp::Node
+class Subscriber : public rclcpp::Node
 {
-  Consumer(const std::string & name, const std::string & input)
-  : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
+public:
+  Subscriber()
+  : Node("subscriber", rclcpp::NodeOptions().use_intra_process_comms(true))
   {
-    // Create a subscription on the input topic which prints on receipt of new messages.
-    sub_ = this->create_subscription<std_msgs::msg::Int32>(
-      input,
-      10,
-      [](std_msgs::msg::Int32::UniquePtr msg) {
-        printf(
-          " Received message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
-          reinterpret_cast<std::uintptr_t>(msg.get()));
-      });
+    subscription_ = this->create_subscription<intra_process_demo_msgs::msg::Data>(
+      "number", 10, std::bind(&Subscriber::topic_callback, this, _1));
   }
 
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_;
+private:
+  void topic_callback(const intra_process_demo_msgs::msg::Data::UniquePtr msg) const
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      " Received message with value: %d, and address: 0x%" PRIXPTR,
+      msg->value,
+      reinterpret_cast<std::uintptr_t>(msg.get()));
+  }
+
+  rclcpp::Subscription<intra_process_demo_msgs::msg::Data>::SharedPtr subscription_;
 };
 
 int main(int argc, char * argv[])
 {
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
   rclcpp::init(argc, argv);
   rclcpp::executors::SingleThreadedExecutor executor;
 
-  auto producer = std::make_shared<Producer>("producer", "number");
-  auto consumer = std::make_shared<Consumer>("consumer", "number");
+  auto publisher = std::make_shared<Publisher>();
+  auto subscriber = std::make_shared<Subscriber>();
 
-  executor.add_node(producer);
-  executor.add_node(consumer);
+  executor.add_node(publisher);
+  executor.add_node(subscriber);
   executor.spin();
 
   rclcpp::shutdown();

--- a/intra_process_demo_msgs/CMakeLists.txt
+++ b/intra_process_demo_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.8)
+project(intra_process_demo_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/intra_process_demo_msgs/CMakeLists.txt
+++ b/intra_process_demo_msgs/CMakeLists.txt
@@ -7,19 +7,21 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
+# generate interfaces
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Data.msg"
+  DEPENDENCIES builtin_interfaces
+)
+
+# export dependencies
+ament_export_dependencies(rosidl_default_runtime)
+
+# test
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/intra_process_demo_msgs/msg/Data.msg
+++ b/intra_process_demo_msgs/msg/Data.msg
@@ -1,0 +1,2 @@
+builtin_interfaces/Time stamp
+int32 value

--- a/intra_process_demo_msgs/package.xml
+++ b/intra_process_demo_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>intra_process_demo_msgs</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="kenjibrameld@gmail.com">ijnek</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/intra_process_demo_msgs/package.xml
+++ b/intra_process_demo_msgs/package.xml
@@ -3,14 +3,21 @@
 <package format="3">
   <name>intra_process_demo_msgs</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>Messages used in demonstrations of intra process communication.</description>
   <maintainer email="kenjibrameld@gmail.com">ijnek</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache License 2.0</license>
+
+  <build_depend>rosidl_default_generators</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Key points to talk about:
- [ ] Brief summary of what happens during intraprocess publishing
    - Does communication happen through DDS?
- [ ] Using a UniquePtr, SharedConstPtr, and a raw object
  - [ ] Unique_ptr is useful if:
    - You want to modify the incoming message, and (optionally) sent out again without any copying at all!
    - Zero-copy only happens if pub/sub it 1-to-1.
  - [ ] Shared_ptr is useful if there is more when there is:
      - than one subscriber
      - you don't want to "lose access" to the msg you sent

New msg type allows the timestamp to be compared, which is important because intra process communication is required when people want to reduce msg latency.

Discussions
- [ ] what's the point of  using a weak_ptr of the publisher in the existing code? It was added in https://github.com/ros2/demos/pull/28, and I'm not sure if it still applies if we're using callback methods and not lambdas?
- [ ] Can we use ``RCLCPP_INFO`` and not ``printf``
- [ ] Do we need ``setvbuf(stdout, NULL, _IONBF, BUFSIZ);`` still?